### PR TITLE
Run injected containers as root

### DIFF
--- a/internal/mutation/gatewayPodMutator.go
+++ b/internal/mutation/gatewayPodMutator.go
@@ -262,7 +262,9 @@ func (cfg gatewayPodMutatorCfg) GatewayPodMutator(_ context.Context, adReview *k
 				}
 			}
 
-			// Create init container
+			// Create sidecar container
+			var sidecarContainerRunAsUser = int64(0) // Run init container as root
+			var sidecarContainerRunAsNonRoot = false
 			container := corev1.Container{
 				Name:    GATEWAY_SIDECAR_CONTAINER_NAME,
 				Image:   cfg.cmdConfig.SidecarImage,
@@ -306,6 +308,8 @@ func (cfg gatewayPodMutatorCfg) GatewayPodMutator(_ context.Context, adReview *k
 						},
 						Drop: []corev1.Capability{},
 					},
+					RunAsUser:    &sidecarContainerRunAsUser,
+					RunAsNonRoot: &sidecarContainerRunAsNonRoot,
 				},
 				// Stdin:                    false,
 				// StdinOnce:                false,

--- a/internal/mutation/gatewayPodMutator_test.go
+++ b/internal/mutation/gatewayPodMutator_test.go
@@ -104,6 +104,8 @@ func getExpectedPodSpec_gateway(gateway string, DNS string, initImage string, si
 	}
 
 	var containers []corev1.Container
+	var sidecarContainerRunAsUser = int64(0) // Run init container as root
+	var sidecarContainerRunAsNonRoot = false
 	if sidecarImage != "" {
 		containers = append(containers, corev1.Container{
 			Name:    mutator.GATEWAY_SIDECAR_CONTAINER_NAME,
@@ -135,6 +137,8 @@ func getExpectedPodSpec_gateway(gateway string, DNS string, initImage string, si
 					},
 					Drop: []corev1.Capability{},
 				},
+				RunAsUser:    &sidecarContainerRunAsUser,
+				RunAsNonRoot: &sidecarContainerRunAsNonRoot,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				corev1.VolumeMount{


### PR DESCRIPTION
**Description of the change**

Modifies the init and sidecar container definitions to run as root user.

**Benefits**

Prevents inheriting the running user from the target pod's security context.

**Possible drawbacks**

No drawbacks identified.

**Applicable issues**

- fixes #38

**Additional information**

