### PR TITLE
chore(internal/mutation): set correct function name in comment

### DIFF
--- a/internal/mutation/gatewayPodMutator.go
+++ b/internal/mutation/gatewayPodMutator.go
@@ -31,7 +31,7 @@ type GatewayPodMutator interface {
 	GatewayPodMutator(ctx context.Context, _ *kwhmodel.AdmissionReview, obj metav1.Object) (*kwhmutating.MutatorResult, error)
 }
 
-// NewLabelMarker returns a new marker that will mark with labels.
+// NewGatewayPodMutator returns a new marker that will mark with labels.
 func NewGatewayPodMutator(cmdConfig config.CmdConfig, logger log.Logger) (GatewayPodMutator, error) {
 
 	logger.Infof("Command config is %#v", cmdConfig)


### PR DESCRIPTION
**Description of the change**

This PR set correct function name in the mutation package factory function `NewGatewayPodMutator`'s header comment.

**Benefits**

It improves code documentation.

**Possible drawbacks**

NA

**Applicable issues**

NA

**Additional information**

NA
