### PR TITLE
Allow to match specific setGateway label and annotation value

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,28 +8,30 @@ import (
 
 // CmdConfig represents the configuration of the command.
 type CmdConfig struct {
-	Debug                bool
-	Development          bool
-	SetGatewayDefault    bool
-	WebhookListenAddr    string
-	MetricsListenAddr    string
-	MetricsPath          string
-	TLSCertFilePath      string
-	TLSKeyFilePath       string
-	Gateway              string
-	DNS                  string
-	DNSPolicy            string
-	SetGatewayLabel      string
-	SetGatewayAnnotation string
-	InitImage            string
-	InitImagePullPol     string
-	InitCmd              string
-	InitMountPoint       string
-	SidecarImage         string
-	SidecarImagePullPol  string
-	SidecarCmd           string
-	SidecarMountPoint    string
-	ConfigmapName        string
+	Debug                     bool
+	Development               bool
+	SetGatewayDefault         bool
+	WebhookListenAddr         string
+	MetricsListenAddr         string
+	MetricsPath               string
+	TLSCertFilePath           string
+	TLSKeyFilePath            string
+	Gateway                   string
+	DNS                       string
+	DNSPolicy                 string
+	SetGatewayLabel           string
+	SetGatewayLabelValue      string
+	SetGatewayAnnotation      string
+	SetGatewayAnnotationValue string
+	InitImage                 string
+	InitImagePullPol          string
+	InitCmd                   string
+	InitMountPoint            string
+	SidecarImage              string
+	SidecarImagePullPol       string
+	SidecarCmd                string
+	SidecarMountPoint         string
+	ConfigmapName             string
 }
 
 var (
@@ -55,7 +57,9 @@ func NewCmdConfig() (*CmdConfig, error) {
 
 	app.Flag("setGatewayDefault", "Set gateway by default in absence of label/annotation").BoolVar(&c.SetGatewayDefault)
 	app.Flag("setGatewayLabel", "Set gateway for pods with this label set to 'true'").StringVar(&c.SetGatewayLabel)
+	app.Flag("setGatewayLabelValue", "Set gateway for pods with label set to this value").StringVar(&c.SetGatewayLabelValue)
 	app.Flag("setGatewayAnnotation", "Set gateway for pods with this annotation set to 'true'").StringVar(&c.SetGatewayAnnotation)
+	app.Flag("setGatewayAnnotationValue", "Set gateway for pods with annotation set to this value").StringVar(&c.SetGatewayAnnotationValue)
 
 	app.Flag("initImage", "Init container image").StringVar(&c.InitImage)
 	app.Flag("initImagePullPol", "Init container pull policy").StringVar(&c.InitImagePullPol)

--- a/internal/mutation/gatewayPodMutator.go
+++ b/internal/mutation/gatewayPodMutator.go
@@ -104,19 +104,47 @@ func (cfg gatewayPodMutatorCfg) GatewayPodMutator(_ context.Context, adReview *k
 	setGateway := cfg.cmdConfig.SetGatewayDefault
 	var err error
 
-	//Check if label excludes this pod
+	// The SetGatewayLabel/SetGatewayAnnotation config controls the label/annotation key of which the value by default
+	// must be 'true' in the pod, in order to inject the default gateway.
+	// Additionally, when configured a value for the setGatewayLabelValue/setGatewayAnnotationValue setting, the value
+	// of the label/annotation specified by SetGatewayLabel/SetGatewayAnnotation must match the configured value
+	// - instead of the default 'true'.
+
+	// If the pod has the configured label.
 	if val, ok := pod.GetLabels()[cfg.cmdConfig.SetGatewayLabel]; cfg.cmdConfig.SetGatewayLabel != "" && ok {
-		setGateway, err = strconv.ParseBool(val)
-		if err != nil {
-			return nil, err
+
+		// If the label requires a specific value, it must match.
+		if setGateway = false; cfg.cmdConfig.SetGatewayLabelValue != "" {
+			if val == cfg.cmdConfig.SetGatewayLabelValue {
+				setGateway = true
+			}
+
+			// Otherwise it must be true.
+		} else {
+
+			setGateway, err = strconv.ParseBool(val)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	//Check if annotations excludes this pod
+	// If the pod has the configured annotation.
 	if val, ok := pod.GetAnnotations()[cfg.cmdConfig.SetGatewayAnnotation]; cfg.cmdConfig.SetGatewayAnnotation != "" && ok {
-		setGateway, err = strconv.ParseBool(val)
-		if err != nil {
-			return nil, err
+
+		// If the annotation requires a specific value, it must match.
+		if setGateway = false; cfg.cmdConfig.SetGatewayAnnotationValue != "" {
+			if val == cfg.cmdConfig.SetGatewayAnnotationValue {
+				setGateway = true
+			}
+
+			// Otherwise it must be true.
+		} else {
+
+			setGateway, err = strconv.ParseBool(val)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/mutation/gatewayPodMutator_test.go
+++ b/internal/mutation/gatewayPodMutator_test.go
@@ -368,7 +368,62 @@ func TestGatewayPodMutator(t *testing.T) {
 				Spec: getExpectedPodSpec_gateway(testGatewayIP, "", testInitImage, ""),
 			},
 		},
-		"setGatewayAnnotation='setGateway' - it should be a NOP since annotation is true": {
+		"setGatewayLabelValue='foo' - it should set gateway since label value matches the config": {
+			cmdConfig: config.CmdConfig{
+				Gateway:              testGatewayIP,
+				SetGatewayDefault:    true,
+				InitImage:            testInitImage,
+				InitCmd:              testInitCmd,
+				InitImagePullPol:     testInitImagePullPol,
+				InitMountPoint:       testInitMountPoint,
+				ConfigmapName:        testConfigmapName,
+				SetGatewayLabel:      "setGateway",
+				SetGatewayLabelValue: "foo",
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"setGateway": "foo",
+					},
+				},
+			},
+			expObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"setGateway": "foo",
+					},
+				},
+				Spec: getExpectedPodSpec_gateway(testGatewayIP, "", testInitImage, ""),
+			},
+		},
+		"setGatewayLabelValue='foo' - it should be a NOP since label value does not match the config": {
+			cmdConfig: config.CmdConfig{
+				Gateway:              testGatewayIP,
+				SetGatewayDefault:    true,
+				InitImage:            testInitImage,
+				InitCmd:              testInitCmd,
+				InitImagePullPol:     testInitImagePullPol,
+				InitMountPoint:       testInitMountPoint,
+				ConfigmapName:        testConfigmapName,
+				SetGatewayLabel:      "setGateway",
+				SetGatewayLabelValue: "foo",
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"setGateway": "bar",
+					},
+				},
+			},
+			expObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"setGateway": "bar",
+					},
+				},
+			},
+		},
+		"setGatewayAnnotation='setGateway' - it should be a NOP since annotation is false": {
 			cmdConfig: config.CmdConfig{
 				Gateway:              testGatewayIP,
 				SetGatewayDefault:    true,
@@ -394,7 +449,7 @@ func TestGatewayPodMutator(t *testing.T) {
 				},
 			},
 		},
-		"setGatewayAnnotation='setGateway' - it should set gateway since annotation is false": {
+		"setGatewayAnnotation='setGateway' - it should set gateway since annotation is true": {
 			cmdConfig: config.CmdConfig{
 				Gateway:              testGatewayIP,
 				SetGatewayDefault:    true,
@@ -419,6 +474,61 @@ func TestGatewayPodMutator(t *testing.T) {
 					},
 				},
 				Spec: getExpectedPodSpec_gateway(testGatewayIP, "", testInitImage, ""),
+			},
+		},
+		"setGatewayAnnotationValue='foo' - it should set gateway since annotation value matches the config": {
+			cmdConfig: config.CmdConfig{
+				Gateway:                   testGatewayIP,
+				SetGatewayDefault:         true,
+				InitImage:                 testInitImage,
+				InitCmd:                   testInitCmd,
+				InitImagePullPol:          testInitImagePullPol,
+				InitMountPoint:            testInitMountPoint,
+				ConfigmapName:             testConfigmapName,
+				SetGatewayAnnotation:      "setGateway",
+				SetGatewayAnnotationValue: "foo",
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"setGateway": "foo",
+					},
+				},
+			},
+			expObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"setGateway": "foo",
+					},
+				},
+				Spec: getExpectedPodSpec_gateway(testGatewayIP, "", testInitImage, ""),
+			},
+		},
+		"setGatewayAnnotationValue='foo' - it should be a NOP since annotation value does not match the config": {
+			cmdConfig: config.CmdConfig{
+				Gateway:                   testGatewayIP,
+				SetGatewayDefault:         true,
+				InitImage:                 testInitImage,
+				InitCmd:                   testInitCmd,
+				InitImagePullPol:          testInitImagePullPol,
+				InitMountPoint:            testInitMountPoint,
+				ConfigmapName:             testConfigmapName,
+				SetGatewayAnnotation:      "setGateway",
+				SetGatewayAnnotationValue: "foo",
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"setGateway": "bar",
+					},
+				},
+			},
+			expObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"setGateway": "bar",
+					},
+				},
 			},
 		},
 		"DNSPolicy": {
@@ -472,6 +582,69 @@ func TestGatewayPodMutator(t *testing.T) {
 			require.NoError(err)
 
 			assert.Equal(test.expObj, test.obj)
+		})
+	}
+}
+
+func TestGatewayPodMutatorReturnsError(t *testing.T) {
+
+	tests := map[string]struct {
+		cmdConfig config.CmdConfig
+		obj       metav1.Object
+	}{
+		"setGatewayLabel='setGateway' - it should return error as the value is not a valid boolean": {
+			cmdConfig: config.CmdConfig{
+				Gateway:           testGatewayIP,
+				SetGatewayDefault: true,
+				InitImage:         testInitImage,
+				InitCmd:           testInitCmd,
+				InitImagePullPol:  testInitImagePullPol,
+				InitMountPoint:    testInitMountPoint,
+				ConfigmapName:     testConfigmapName,
+				SetGatewayLabel:   "setGateway",
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"setGateway": "notbool",
+					},
+				},
+			},
+		},
+		"setGatewayAnnotation='setGateway' - it should return error as the value is not a valid boolean": {
+			cmdConfig: config.CmdConfig{
+				Gateway:              testGatewayIP,
+				SetGatewayDefault:    true,
+				InitImage:            testInitImage,
+				InitCmd:              testInitCmd,
+				InitImagePullPol:     testInitImagePullPol,
+				InitMountPoint:       testInitMountPoint,
+				ConfigmapName:        testConfigmapName,
+				SetGatewayAnnotation: "setGateway",
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"setGateway": "notbool",
+					},
+				},
+			},
+		},
+	}
+
+	logrusLog := logrus.New()
+	logrusLogEntry := logrus.NewEntry(logrusLog).WithField("app", "gatewayPodMutator Test for errors")
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			m, err := mutator.NewGatewayPodMutator(test.cmdConfig, log.NewLogrus(logrusLogEntry).WithKV(log.KV{"test": name}))
+			require.NoError(err)
+
+			_, err = m.GatewayPodMutator(context.TODO(), nil, test.obj)
+			assert.Error(err)
 		})
 	}
 }


### PR DESCRIPTION
**Description of the change**

This feature will allow to deploy multiple pod-gateways in a single cluster, by providing a way for client pods to select a specific pod-gateway, that a specific gateway-admission-controller instance will be inject.

The user experience is kept consistent. New string flags for the label and the annotation are available to the end-user:
- `--setGatewayLabelValue`
- `--setGatewayAnnotationValue`

that when set, will require the value to match value of the label/annotation of the client pods, of which the key is set through the `--setGatewayLabel`/`--setGatewayAnnotation` flag.

**Benefits**

Allow to deploy multiple gateways in the same cluster and inject arbitrary gateways into specific client pods.

**Possible drawbacks**

Managing multiple pod-gatways in the same cluster will need one mutating admission controller per gateway. 

**Applicable issues**

- fixes #102

**Additional information**

NA
