### PR TITLE
Support sidecar as init container

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type CmdConfig struct {
 	SidecarImagePullPol       string
 	SidecarCmd                string
 	SidecarMountPoint         string
+	SidecarAsInit             bool
 	ConfigmapName             string
 }
 
@@ -70,6 +71,7 @@ func NewCmdConfig() (*CmdConfig, error) {
 	app.Flag("sidecarImagePullPol", "Sidecar container pull policy").StringVar(&c.SidecarImagePullPol)
 	app.Flag("sidecarCmd", "Sidecard command to execute instead of container default").StringVar(&c.SidecarCmd)
 	app.Flag("sidecarMountPoint", "Mountpoint for configmap in sidecar container").StringVar(&c.SidecarMountPoint)
+	app.Flag("sidecarAsInit", "Create the sidecar as an init container. Requires Kubernetes v1.29").BoolVar(&c.SidecarAsInit)
 
 	app.Flag("configmapName", "Name of the configmap to attach to containers").StringVar(&c.ConfigmapName)
 

--- a/internal/mutation/gatewayPodMutator.go
+++ b/internal/mutation/gatewayPodMutator.go
@@ -374,7 +374,14 @@ func (cfg gatewayPodMutatorCfg) GatewayPodMutator(_ context.Context, adReview *k
 			}
 
 			//Add container to pod
-			pod.Spec.Containers = append(pod.Spec.Containers, container)
+			if cfg.cmdConfig.SidecarAsInit {
+				rs := corev1.ContainerRestartPolicyAlways
+				container.RestartPolicy = &rs
+
+				pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
+			} else {
+				pod.Spec.Containers = append(pod.Spec.Containers, container)
+			}
 		}
 
 		if cfg.cmdConfig.ConfigmapName != "" {


### PR DESCRIPTION
**Description of the change**

Support creating sidecar as an init container so the sidecar will stop when the main container is complete. This was added in Kubernetes version 1.29 and added a chart option to keep existing functionality or us the new sidecar feature.

**Benefits**

Cron jobs that use the current pod-gateway sidecar do not stop running when the job is complete and makes it difficult to determine the state of the job.

**Possible drawbacks**

Does not work on older versions of Kubernetes.

**Applicable issues**

- fixes #295

**Additional information**

NA
